### PR TITLE
Insert fallback for webkit (Safari, really) audiocontext creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
     "react-scripts": "^4.0.0",
+    "standardized-audio-context": "^25.1.9",
     "typescript": "^3.8.3"
   },
   "scripts": {

--- a/src/skulpt-connection/sound-manager.ts
+++ b/src/skulpt-connection/sound-manager.ts
@@ -6,7 +6,7 @@ export class BrowserSoundManager {
   runningPerformances: Array<BrowserSoundPerformance>;
 
   constructor() {
-    const AudioContext = window.AudioContext;
+    const AudioContext = window.AudioContext || (window as any).webkitAudioContext; // everyone vs. Safari...
     this.audioContext = new AudioContext();
     this.runningPerformances = [];
   }

--- a/src/skulpt-connection/sound-manager.ts
+++ b/src/skulpt-connection/sound-manager.ts
@@ -1,4 +1,6 @@
 import { assetServer } from "./asset-server";
+import { AudioContext } from 'standardized-audio-context';
+
 declare var Sk: any;
 
 export class BrowserSoundManager {
@@ -6,7 +8,6 @@ export class BrowserSoundManager {
   runningPerformances: Array<BrowserSoundPerformance>;
 
   constructor() {
-    const AudioContext = window.AudioContext || (window as any).webkitAudioContext; // everyone vs. Safari...
     this.audioContext = new AudioContext();
     this.runningPerformances = [];
   }
@@ -18,7 +19,6 @@ export class BrowserSoundManager {
     // a copy to work with:
     const audioData = (await assetServer.loadSoundData(name)).slice(0);
     const audioBuffer = await this.audioContext.decodeAudioData(audioData);
-
     return new BrowserSound(this, tag, audioBuffer);
   }
 
@@ -64,6 +64,8 @@ class BrowserSound {
     let soundManager = this.parentSoundManager;
     let bufferSource = soundManager.createBufferSource();
     bufferSource.buffer = this.audioBuffer;
+
+    // @ts-ignore -- detune not implemented in AudioBufferSourceNode
     return bufferSource;
   }
 }


### PR DESCRIPTION
Safari doesn't implement window.AudioContext, but it does have
the Web Audio API with a vendor prefix. Older versions of Chrome
need this too, I hear.

I think the 'as any' declaration could be avoided by including
a type definition for webkitAudioContext in the window interface
(see https://github.com/microsoft/TypeScript/issues/31686 )
and I believe these are in some community definitions somewhere?