### PR TITLE
LowerCase letters to vm for key_pressed()

### DIFF
--- a/cypress/e2e/keypresses.cy.ts
+++ b/cypress/e2e/keypresses.cy.ts
@@ -22,11 +22,13 @@ context("Keypress handling", () => {
     cy.pytchSendKeysToProject("a");
     cy.pytchStdoutShouldContain("hello\nhello\n");
 
-    cy.pytchSendKeysToApp("a");
+    cy.pytchSendKeysToApp("A");
     cy.pytchStdoutShouldContain("hello\nhello\nhello\n");
 
     cy.pytchRedStop();
     cy.pytchSendKeysToApp("a");
     cy.pytchStdoutShouldContain("hello\nhello\nhello\nhello\n");
+    cy.pytchSendKeysToApp("A");
+    cy.pytchStdoutShouldContain("hello\nhello\nhello\nhello\nhello\n");
   });
 });

--- a/src/skulpt-connection/browser-keyboard.ts
+++ b/src/skulpt-connection/browser-keyboard.ts
@@ -3,6 +3,12 @@ declare let Sk: any;
 
 type KeyName = string;
 
+function canonicalKeyName(e: KeyboardEvent): string {
+  const key = e.key;
+  //The vm expect LowerCase letters for key_pressed()
+  return (key.length === 1 && key.match(/[A-Z]/)) ? key.toLowerCase() : key;
+}
+
 export class BrowserKeyboard {
   undrainedKeydownKeys: Array<KeyName>;
   keyIsDown: Map<KeyName, boolean>;
@@ -18,13 +24,15 @@ export class BrowserKeyboard {
   }
 
   onKeyDown(e: KeyboardEvent) {
-    this.keyIsDown.set(e.key, true);
-    this.undrainedKeydownKeys.push(e.key);
+    var key = canonicalKeyName(e);
+    this.keyIsDown.set(key, true);
+    this.undrainedKeydownKeys.push(key);
     e.preventDefault();
   }
 
   onKeyUp(e: KeyboardEvent) {
-    this.keyIsDown.set(e.key, false);
+    var key = canonicalKeyName(e);
+    this.keyIsDown.set(key, false);
     e.preventDefault();
   }
 


### PR DESCRIPTION
Add canonicalKeyName(e: KeyboardEvent), to return e.key.toLowerCase() if e.key is a capital letter A-Z, for onKeyDown and onKeyUp. (The vm expect LowerCase letters for key_pressed())
Extend the existing test keypressed.cy.ts testing also capital letters.